### PR TITLE
fix setCallOnEvent performance

### DIFF
--- a/js/caller.js
+++ b/js/caller.js
@@ -108,7 +108,7 @@
 		setCallOnEvent: function () {
 			var self = this;
 
-			$('[data-' + self.attrOnEvent + '!="load"]').each(function (index, item) {
+			$('[data-' + self.attrOnEvent + ']').not('[data-' + self.attrOnEvent + '="load"]').each(function (index, item) {
 				$(item).on($(item).data(self.attrOnEvent), function () { self.call(item) });
 			});
 		},


### PR DESCRIPTION
The current filter returns all element without '[data-' + self.attrOnEvent + '!="load"]', including elements without "data-call-*" attribute.